### PR TITLE
Added invalid swap feature

### DIFF
--- a/app.js
+++ b/app.js
@@ -127,10 +127,12 @@ function moveIntoSquareBelow() {
         rowOfFour.forEach(index => {
         squares[index].style.backgroundImage = ''
         })
+        return true;
       }
     }
+    return false;
   }
-  checkRowForFour()
+
 
 //for column of Four
   function checkColumnForFour() {
@@ -145,10 +147,12 @@ function moveIntoSquareBelow() {
         columnOfFour.forEach(index => {
         squares[index].style.backgroundImage = ''
         })
+        return true;
       }
     }
+    return false;
   }
-checkColumnForFour()
+
 
   //for row of Three
   function checkRowForThree() {
@@ -166,10 +170,12 @@ checkColumnForFour()
         rowOfThree.forEach(index => {
         squares[index].style.backgroundImage = ''
         })
+        return true;
       }
     }
+    return false;
   }
-  checkRowForThree()
+
 
 //for column of Three
   function checkColumnForThree() {
@@ -184,10 +190,11 @@ checkColumnForFour()
         columnOfThree.forEach(index => {
         squares[index].style.backgroundImage = ''
         })
+        return true;
       }
     }
+    return false;
   }
-checkColumnForThree()
 
 // Checks carried out indefintely - Add Butotn to clear interval for best practise
 window.setInterval(function(){

--- a/app.js
+++ b/app.js
@@ -74,7 +74,19 @@ function dragEnd() {
     let validMove = validMoves.includes(squareIdBeingReplaced)
 
     if (squareIdBeingReplaced && validMove) {
-        squareIdBeingReplaced = null
+      let scoredRowOfFour = checkRowForFour();
+      let scoredColumnOfFour = checkColumnForFour();
+      let scoredRowOfThree = checkRowForThree();
+      let scoredColumnOfThree = checkColumnForThree();
+      //check if any combo was scored
+      if(scoredRowOfFour || scoredColumnOfFour || scoredRowOfThree || scoredColumnOfThree){
+        squareIdBeingReplaced = null;
+      }
+      //if no combo scored swap back to original candies
+      else if(!scoredRowOfFour && !scoredColumnOfFour && !scoredRowOfThree && !scoredColumnOfThree){
+        squares[squareIdBeingDragged].style.backgroundImage = colorBeingDragged;
+        squares[squareIdBeingReplaced].style.backgroundImage = colorBeingReplaced;
+      }
     }  else if (squareIdBeingReplaced && !validMove) {
        squares[squareIdBeingReplaced].style.backgroundImage = colorBeingReplaced
        squares[squareIdBeingDragged].style.backgroundImage = colorBeingDragged


### PR DESCRIPTION
### feature
In the actual candy crush game, you cannot swap two candies if they don't make a match. But we could do that in your version of the game. I changed that by adding boolean return values to the functions which check for matches, and then using those booleans to validate or invalidate the players swaps.